### PR TITLE
Update Broken Anaconda links

### DIFF
--- a/ipynb/GettingSetup.ipynb
+++ b/ipynb/GettingSetup.ipynb
@@ -20,7 +20,7 @@
    "source": [
     "## Downloading and Installing Jupyter with Anaconda\n",
     "\n",
-    "[<img src=\"images/logo_anaconda.png\" alt=\"Anaconda logo\" style=\"float: right; width: 100px; margin-left: 1em;\" />](https://www.continuum.io/downloads)  Setting up Jupyter is (usually) a smooth and painless process. The easiest and recommended option is to [download and install Anaconda](https://www.continuum.io/downloads), which is a freely available bundle that includes Python, Jupyter, and several other things that will be useful to us. It's *very important* for the purposes of our notebooks to select a version for [Mac OS X](https://www.continuum.io/downloads#_macosx), [Windows](https://www.continuum.io/downloads#_windows) or [Linux](https://www.continuum.io/downloads#_unix) of **Anaconda with Python 3.x** (not Python 2.x).\n",
+    "[<img src=\"images/logo_anaconda.png\" alt=\"Anaconda logo\" style=\"float: right; width: 100px; margin-left: 1em;\" />](https://www.continuum.io/downloads)  Setting up Jupyter is (usually) a smooth and painless process. The easiest and recommended option is to [download and install Anaconda](https://www.anaconda.com/distribution/#download-section), which is a freely available bundle that includes Python, Jupyter, and several very other things that will be useful to us. It's *very important* for the purposes of our notebooks to select a version for your operating system titled **Python 3.x** (not Python 2.x).\n",
     "\n",
     "Once the Anaconda 3.x installer program is downloaded you can click on the installer and follow the instructions (using the defaults will work just fine). If you encounter difficulties, you may want to consult the [Jupyter installation documentation](http://jupyter.readthedocs.org/en/latest/install.html)."
    ]
@@ -118,7 +118,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The links for installation downloads were broken, so I put in the new ones. Also, there are no OS-specific links anymore - anaconda.com selects the OS automatically.